### PR TITLE
Update 7 parameter snippet

### DIFF
--- a/snippets-production/7params-production.js
+++ b/snippets-production/7params-production.js
@@ -1,4 +1,4 @@
-!function(A,B,C,D,E,F,G){A.GoogleAnalyticsObject=C;A[C]||(A[C]=function(){
-(A[C].q=A[C].q||[]).push(arguments)});A[C].l=+new Date;F=B.createElement(D);
-G=B.getElementsByTagName(D)[0];F.src=E;G.parentNode.insertBefore(F,G)}
-(window,document,"ga","script","//www.google-analytics.com/analytics.js");
+(function(A,B,C,D,E,F,G){A['GoogleAnalyticsObject']=E;A[E]=A[E]||function(){
+(A[E].q=A[E].q||[]).push(arguments)},A[E].G=1*new Date();F=B.createElement(C),
+G=B.getElementsByTagName(C)[0];F.async=1;F.src=D;G.parentNode.insertBefore(F,G)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');


### PR DESCRIPTION
The current snippet recommended by Google differs from what is currently in the repository. Most notable, the `async` attribute is now set on the injected tag. 
